### PR TITLE
create header cache layer outside VSIFile object

### DIFF
--- a/tests/test_multithreads.py
+++ b/tests/test_multithreads.py
@@ -5,8 +5,9 @@ import os
 import random
 from unittest.mock import patch
 
+from diskcache import Cache
+
 from vsifile import VSIFile
-from vsifile.settings import VSISettings
 
 fixtures_dir = os.path.join(os.path.dirname(__file__), "fixtures")
 cog = os.path.join(fixtures_dir, "cog.tif")
@@ -17,13 +18,8 @@ def test_vsifile_multithread(tmp_path):
     d = tmp_path / "cache"
     d.mkdir()
 
-    with patch(
-        "vsifile.io.base.vsi_settings",
-        new=VSISettings(
-            cache_headers_ttl=10,
-            cache_directory=str(d),
-        ),
-    ):
+    cache = Cache(directory=str(d), size_limit=5120000000)
+    with patch("vsifile.io.base.header_cache", new=cache):
 
         def _read_range(start, stop):
             with VSIFile(cog, "rb") as f:

--- a/vsifile/io/base.py
+++ b/vsifile/io/base.py
@@ -11,21 +11,21 @@ from cachetools.keys import hashkey
 from diskcache import Cache
 
 from vsifile.logger import logger
-from vsifile.settings import vsi_settings
+from vsifile.settings import VSISettings
 
+vsi_settings = VSISettings()
+
+# TTL Block Cache (in-memory)
 block_cache: TTLCache = TTLCache(
     maxsize=vsi_settings.cache_blocks_maxsize,
     ttl=vsi_settings.cache_blocks_ttl,
 )
 
-
-def init_header_cache():
-    """Create or Connect to Header Cache layer."""
-    logger.debug(f"Using {vsi_settings.cache_directory} Cache directory")
-    return Cache(
-        directory=vsi_settings.cache_directory,
-        size_limit=vsi_settings.cache_headers_maxsize,
-    )
+# TTL Header Cache (in-disk)
+header_cache: Cache = Cache(
+    directory=vsi_settings.cache_directory,
+    size_limit=vsi_settings.cache_headers_maxsize,
+)
 
 
 def _check_mode(instance, attribute, value):
@@ -43,8 +43,7 @@ class BaseReader(metaclass=abc.ABCMeta):
     mode: str = field(default="rb", validator=_check_mode)
 
     header: Union[str, bytes] = field(init=False)
-    header_len: int = field(init=False)
-    header_cache: Cache = field(init=False, factory=init_header_cache)
+    header_cache: Cache = field(init=False, factory=lambda: header_cache)
 
     def __repr__(self) -> str:
         """Reader repr."""

--- a/vsifile/io/file.py
+++ b/vsifile/io/file.py
@@ -33,7 +33,6 @@ class FileReader(BaseReader):
 
     def close(self):
         """Close."""
-        self.header_cache.close()
         self.file.close()
 
     def seekable(self) -> bool:

--- a/vsifile/io/http.py
+++ b/vsifile/io/http.py
@@ -41,7 +41,6 @@ class HttpReader(BaseReader):
 
     def close(self):
         """Close."""
-        self.header_cache.close()
         self.client.close()
 
     @property

--- a/vsifile/io/s3.py
+++ b/vsifile/io/s3.py
@@ -101,7 +101,6 @@ class AWSS3Reader(BaseReader):
 
     def close(self):
         """Close."""
-        self.header_cache.close()
         self.client.close()
         self.is_closed = True
 

--- a/vsifile/settings.py
+++ b/vsifile/settings.py
@@ -39,6 +39,3 @@ class VSISettings(BaseSettings):
             self.cache_blocks_maxsize = 0
 
         return self
-
-
-vsi_settings = VSISettings()


### PR DESCRIPTION
ref #11 #13 

```
$ VSIFILE_CACHE_DISABLE=TRUE tilebench profile  tests/fixtures/cog.tif --reader rio_viz.io.reader.VSIReader --tile 8-88-49 --add-cprofile | jq 
{
  "HEAD": {
    "count": 0
  },
  "GET": {
    "count": 0,
    "bytes": 0,
    "ranges": []
  },
  "Timing": 0.043890953063964844,
  "cprofile": [
    "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)",
    "        1    0.012    0.012    0.015    0.015 reader.py:86(read)",
    "        1    0.011    0.011    0.013    0.013 __init__.py:98(open)",
    "        1    0.004    0.004    0.004    0.004 warp.py:453(calculate_default_transform)",
    "        1    0.003    0.003    0.003    0.003 warp.py:113(transform_bounds)",
    "   765/19    0.002    0.000    0.002    0.000 {built-in method _abc._abc_subclasscheck}",
    "        1    0.001    0.001    0.001    0.001 rasterio.py:91(__attrs_post_init__)"
  ]
}

$ tilebench profile  tests/fixtures/cog.tif --reader rio_viz.io.reader.VSIReader --tile 8-88-49 --add-cprofile | jq
{
  "HEAD": {
    "count": 0
  },
  "GET": {
    "count": 0,
    "bytes": 0,
    "ranges": []
  },
  "Timing": 0.05856895446777344,
  "cprofile": [
    "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)",
    "        1    0.016    0.016    0.025    0.025 __init__.py:98(open)",
    "        1    0.011    0.011    0.015    0.015 reader.py:86(read)",
    "        9    0.005    0.001    0.005    0.001 {method 'execute' of 'sqlite3.Connection' objects}",
    "        1    0.005    0.005    0.005    0.005 warp.py:453(calculate_default_transform)",
    "        1    0.003    0.003    0.003    0.003 warp.py:113(transform_bounds)",
    "   765/19    0.002    0.000    0.002    0.000 {built-in method _abc._abc_subclasscheck}",
    "        6    0.001    0.000    0.001    0.000 {method 'read' of '_io.BufferedReader' objects}",
    "       95    0.001    0.000    0.001    0.000 {method 'write' of '_io.BufferedWriter' objects}",
    "        1    0.001    0.001    0.001    0.001 rasterio.py:91(__attrs_post_init__)"
  ]
}

$ tilebench profile tests/fixtures/cog.tif --tile 8-88-49 --add-cprofile | jq                                                   
{
  "HEAD": {
    "count": 0
  },
  "GET": {
    "count": 0,
    "bytes": 0,
    "ranges": []
  },
  "Timing": 0.04011726379394531,
  "cprofile": [
    "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)",
    "        1    0.012    0.012    0.014    0.014 reader.py:86(read)",
    "        1    0.011    0.011    0.012    0.012 __init__.py:98(open)",
    "        1    0.004    0.004    0.004    0.004 warp.py:453(calculate_default_transform)",
    "        1    0.003    0.003    0.003    0.003 warp.py:113(transform_bounds)",
    "    593/9    0.001    0.000    0.001    0.000 {built-in method _abc._abc_subclasscheck}"
  ]
}
```