### PR TITLE
Feature/fake size mtime

### DIFF
--- a/vsifile/io/base.py
+++ b/vsifile/io/base.py
@@ -70,7 +70,7 @@ class BaseReader(metaclass=abc.ABCMeta):
         ...
 
     def _get_header(self) -> bytes:
-        logger.debug("VSIFILE_INFO: HEAD")
+        logger.debug("VSIFILE_INFO: HEAD (Open)")
         head = obs.head(self._store, self._key)
         self._size = head["size"]
 
@@ -126,7 +126,7 @@ class BaseReader(metaclass=abc.ABCMeta):
     @cached_property
     def mtime(self) -> datetime.datetime:
         """return file modified date."""
-        logger.debug("VSIFILE_INFO: HEAD")
+        logger.debug("VSIFILE_INFO: HEAD (mtime)")
         head = obs.head(self._store, self._key)
         return head["last_modified"]
 
@@ -138,7 +138,7 @@ class BaseReader(metaclass=abc.ABCMeta):
     @cached_property
     def seekable(self) -> bool:
         """file seekable."""
-        logger.debug("VSIFILE_INFO: HEAD")
+        logger.debug("VSIFILE_INFO: HEAD (seekable)")
         return obs.head(self._store, self._key) is not None
 
     def seek(self, loc: int, whence: int = 0) -> int:

--- a/vsifile/rasterio.py
+++ b/vsifile/rasterio.py
@@ -40,13 +40,11 @@ class VSIOpener:
 
     def mtime(self, path) -> int:
         """mtime."""
-        with self._obj(path, mode="rb") as f:
-            return f.mtime
+        return 0
 
     def size(self, path) -> int:
         """size."""
-        with self._obj(path, mode="rb") as f:
-            return f.size
+        return 1
 
 
 MultiByteRangeResourceContainer.register(VSIOpener)


### PR DESCRIPTION
I'm not sure why rasterio.opener needs `.size` and `.mtime` but adding those `fake` response makes the lib 2 times faster 😅 

`opener.size` is used here https://github.com/rasterio/rasterio/blob/7854084b8161456dd798280e2dca2a515e6c2d54/rasterio/_vsiopener.pyx#L378-L386

and https://github.com/rasterio/rasterio/blob/7854084b8161456dd798280e2dca2a515e6c2d54/rasterio/_vsiopener.pyx#L80-L81 (but we don't implement `pyopener_stat`)  