### PR TITLE
Ignore unrelated variables in .env

### DIFF
--- a/vsifile/settings.py
+++ b/vsifile/settings.py
@@ -27,6 +27,7 @@ class VSISettings(BaseSettings):
     model_config = {
         "env_prefix": "VSIFILE_",
         "env_file": ".env",
+        "extra": "ignore",
     }
 
     @model_validator(mode="after")


### PR DESCRIPTION
Hi,

I was just testing out `vsifile` and noticed an issue coming from the pydantic settings parsing from the `.env` file.

I tried to import `vsifile` from a directory with a `.env` file that contains different variables completely unrelated to `vsifile` - which caused the import to fail.


To reproduce:

```python
from pathlib import Path

Path(".env").write_text("SOME_VAR=foo")


import vsifile  # raises ValidationError
```

```
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[3], line 5
      1 from pathlib import Path
      3 Path(".env").write_text("SOME_VAR=foo")
----> 5 import vsifile

File [~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/vsifile/__init__.py:6](http://localhost:8888/lab/tree/examples/wyvern-hyperspectral-pca/extra/~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/vsifile/__init__.py#line=5)
      3 from typing import Type
      4 from urllib.parse import urlparse
----> 6 from .io import AWSS3Reader, BaseReader, FileReader, HttpReader
      8 __version__ = "0.4.0"
     11 def _get_filesystem_class(protocol) -> Type[BaseReader]:
     12     # [https://{hostname}/{path](https://{hostname}/%7Bpath)}

File [~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/vsifile/io/__init__.py:3](http://localhost:8888/lab/tree/examples/wyvern-hyperspectral-pca/extra/~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/vsifile/io/__init__.py#line=2)
      1 """vsifile.io"""
----> 3 from .base import BaseReader  # noqa
      4 from .file import FileReader  # noqa
      5 from .http import HttpReader  # noqa

File [~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/vsifile/io/base.py:28](http://localhost:8888/lab/tree/examples/wyvern-hyperspectral-pca/extra/~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/vsifile/io/base.py#line=27)
     18 if TYPE_CHECKING:
     19     from obstore.store import (
     20         AzureConfigInput,
     21         ClientConfig,
   (...)     25         S3ConfigInput,
     26     )
---> 28 vsi_settings = VSISettings()
     30 # TTL Block Cache (in-memory)
     31 block_cache: TTLCache = TTLCache(
     32     maxsize=vsi_settings.cache_blocks_maxsize,
     33     ttl=vsi_settings.cache_blocks_ttl,
     34 )

File [~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/pydantic_settings/main.py:188](http://localhost:8888/lab/tree/examples/wyvern-hyperspectral-pca/extra/~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/pydantic_settings/main.py#line=187), in BaseSettings.__init__(__pydantic_self__, _case_sensitive, _nested_model_default_partial_update, _env_prefix, _env_file, _env_file_encoding, _env_ignore_empty, _env_nested_delimiter, _env_nested_max_split, _env_parse_none_str, _env_parse_enums, _cli_prog_name, _cli_parse_args, _cli_settings_source, _cli_parse_none_str, _cli_hide_none_type, _cli_avoid_json, _cli_enforce_required, _cli_use_class_docs_for_groups, _cli_exit_on_error, _cli_prefix, _cli_flag_prefix_char, _cli_implicit_flags, _cli_ignore_unknown_args, _cli_kebab_case, _cli_shortcuts, _secrets_dir, **values)
    158 def __init__(
    159     __pydantic_self__,
    160     _case_sensitive: bool | None = None,
   (...)    186     **values: Any,
    187 ) -> None:
--> 188     super().__init__(
    189         **__pydantic_self__._settings_build_values(


File [~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/pydantic/main.py:253](http://localhost:8888/lab/tree/examples/wyvern-hyperspectral-pca/extra/~/Documents/tilebox/examples/wyvern-hyperspectral-pca/.venv/lib/python3.13/site-packages/pydantic/main.py#line=252), in BaseModel.__init__(self, **data)
    251 # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
    252 __tracebackhide__ = True
--> 253 validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
    254 if self is not validated_self:
    255     warnings.warn(
    256         'A custom validator is returning a value other than `self`.\n'
    257         "Returning anything other than `self` from a top level model validator isn't supported when validating via `__init__`.\n"
    258         'See the `model_validator` docs (https://docs.pydantic.dev/latest/concepts/validators/#model-validators) for more details.',
    259         stacklevel=2,
    260     )

ValidationError: 1 validation error for VSISettings
some_var
  Extra inputs are not permitted [type=extra_forbidden, input_value='foo', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
```

Setting `"extra": "ignore"` in the model settings fixes the issue.

To be completely honest, I have no idea why that is the case, since the [pydantic docs](https://docs.pydantic.dev/2.11/api/config/#pydantic.config.ConfigDict.extra) mention:

> Whether to ignore, allow, or forbid extra data during model initialization. Defaults to 'ignore'.

Apparently for me for some reason it instead defaults to `forbid` 😅 


Some more env info for reproducability:

```
Python 3.13.1 on MacOS

vsifile==0.4.0
pydantic==2.11.7
pydantic-core==2.33.2
pydantic-settings==2.10.1
```